### PR TITLE
Fix issue with psycopg 2.2.1 where it can't take a None factory.

### DIFF
--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -290,7 +290,10 @@ class Connection(object):
         [2]: http://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-PQCONNECTDBPARAMS
         [3]: http://initd.org/psycopg/docs/connection.html#connection
         """
-        self._connection = psycopg2.connect(dsn, connection_factory, async=1)
+        args = []
+        if not connection_factory is None:
+          args.append(connection_factory)
+        self._connection = psycopg2.connect(dsn, *args, async=1)
         self._fileno = self._connection.fileno()
         self._callbacks = callbacks
 


### PR DESCRIPTION
On the version of psycopg2 on Squeeze (2.2.1), passing None as the connection_factory raises an exception.  This changes it to not pass that argument at all when it's None.
