### PR TITLE
Support for NamedTupleConnection/DictConnection.

### DIFF
--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -285,7 +285,10 @@ class Connection:
         .. _psycopg2.extensions.cursor: http://initd.org/psycopg/docs/extensions.html#psycopg2.extensions.cursor
         .. _Connection and cursor factories: http://initd.org/psycopg/docs/advanced.html#subclassing-cursor
         """
-        cursor = self.connection.cursor(cursor_factory=cursor_factory or base_cursor)
+        kwargs={}
+        if cursor_factory:
+            kwargs.setdefault('cursor_factory', cursor_factory)
+        cursor = self.connection.cursor(**kwargs)
         cursor.execute(operation, parameters)
         self.callback = partial(callback or _dummy_callback, cursor)
         self.ioloop.add_handler(self.fileno, self.io_callback, IOLoop.WRITE)
@@ -326,7 +329,10 @@ class Connection:
         .. _psycopg2.extensions.cursor: http://initd.org/psycopg/docs/extensions.html#psycopg2.extensions.cursor
         .. _Connection and cursor factories: http://initd.org/psycopg/docs/advanced.html#subclassing-cursor
         """
-        cursor = self.connection.cursor(cursor_factory=cursor_factory or base_cursor)
+        kwargs={}
+        if cursor_factory:
+            kwargs.setdefault('cursor_factory', cursor_factory)
+        cursor = self.connection.cursor(**kwargs)
         cursor.callproc(procname, parameters)
         self.callback = partial(callback or _dummy_callback, cursor)
         self.ioloop.add_handler(self.fileno, self.io_callback, IOLoop.WRITE)


### PR DESCRIPTION
This allows using `connection_factory` types `psycopg2.extras.NamedTupleConnection` or `DictConnection`. If `cursor_factory` is not defined will be used `connection_factory` default.

Example:

```
self.db = momoko.Pool(dsn=settings['dsn'], size=settings['db_conn_size'], connection_factory=psycopg2.extras.NamedTupleConnection)
```
