### PR TITLE
Tornado 4.0 compatablity

### DIFF
--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -235,7 +235,7 @@ class Pool(object):
 
         if self._conns.last_connect_attempt_success:
             # Connection to db is OK. If we have waiting requests
-            # and some dead conncetions, we can serve requests faster
+            # and some dead connections, we can serve requests faster
             # if we reanimate dead connections
             num_conns_to_reconnect = min(len(self._conns.dead), len(self._conns.waiting_queue))
             for i in range(num_conns_to_reconnect):

--- a/momoko/utils.py
+++ b/momoko/utils.py
@@ -25,7 +25,42 @@ else:
 log = logging.getLogger('momoko')
 
 
-class Op(gen.Task):
+class Task(gen.YieldPoint):
+    """Runs a single asynchronous operation.
+
+    Takes a function (and optional additional arguments) and runs it with
+    those arguments plus a ``callback`` keyword argument.  The argument passed
+    to the callback is returned as the result of the yield expression.
+
+    A `Task` is equivalent to a `Callback`/`Wait` pair (with a unique
+    key generated automatically)::
+
+        result = yield gen.Task(func, args)
+
+        func(args, callback=(yield gen.Callback(key)))
+        result = yield gen.Wait(key)
+    """
+    def __init__(self, func, *args, **kwargs):
+        assert "callback" not in kwargs
+        self.args = args
+        self.kwargs = kwargs
+        self.func = func
+
+    def start(self, runner):
+        self.runner = runner
+        self.key = object()
+        runner.register_callback(self.key)
+        self.kwargs["callback"] = runner.result_callback(self.key)
+        self.func(*self.args, **self.kwargs)
+
+    def is_ready(self):
+        return self.runner.is_ready(self.key)
+
+    def get_result(self):
+        return self.runner.pop_result(self.key)
+
+
+class Op(Task):
     """
     Run a single asynchronous operation.
 


### PR DESCRIPTION
Backported old Task class for Tornado 4.0 compatablity. This
will hold until we migrate to new interface.

Should fix #75.
