### PR TITLE
Catching ALL types of early error. Fixes #79.

### DIFF
--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -606,7 +606,7 @@ class Connection(object):
             callback = kwargs.get("callback", _dummy_callback)
             try:
                 return func(self, *args, **kwargs)
-            except psycopg2.Error as error:
+            except Exception as error:
                 callback(None, error)
         return wrapper
 

--- a/tests.py
+++ b/tests.py
@@ -326,6 +326,16 @@ class MomokoTest(MomokoBaseDataTest):
 
         self.assert_raises(psycopg2.ProgrammingError, self.run_gen, func)
 
+    def test_op_early_exception(self):
+        """Testing that Op propagates early exceptions properly"""
+        @gen.engine
+        def func():
+            cursor = yield momoko.Op(self.db.execute, 'SELECT %s FROM %s', ())
+            self.stop()
+
+        self.assert_raises(IndexError, self.run_gen, func)
+        self.assertFalse(self.db._conns.busy, msg="Busy connction was not returned to pool after exception")
+
     def test_wait_op(self):
         """Testing WaitOp"""
         @gen.engine


### PR DESCRIPTION
Its important to catch any type of early error and pass
it back properly to give inner callback a chance to return
connection back to free pool.

Signed-off-by: Zaar Hai haizaar@haizaar.com
