### PR TITLE
Fixed Psycopg2 link error.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -70,7 +70,7 @@ Fixes:
 * Replaced dynamic connection pool with a static one.
 * Add support for hstore_.
 
-.. _Psycopg2: http://www.initd.org/psycopg/
+.. _Psycopg2: http://initd.org/psycopg/
 .. _psycopg2ct: http://pypi.python.org/pypi/psycopg2ct
 .. _psycopg2cffi: http://pypi.python.org/pypi/psycopg2cffi
 .. _pull request 38: https://github.com/FSX/momoko/pull/38

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ The lastest source code can be found on Github_ and bug reports can be send
 there too. All releases will be uploaded to PyPi_.
 
 
-.. _Psycopg2: http://www.initd.org/psycopg/
+.. _Psycopg2: http://initd.org/psycopg
 .. _Tornado: http://www.tornadoweb.org
 .. _Github: https://github.com/FSX/momoko
 .. _PyPi: https://pypi.python.org/pypi/Momoko


### PR DESCRIPTION
There should be no `www.` in the link url.
