### PR TITLE
Bye-bye psycopg2ct

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_script:
 
 env:
   - MOMOKO_PSYCOPG2_IMPL=psycopg2
-  - MOMOKO_PSYCOPG2_IMPL=psycopg2ct
   - MOMOKO_PSYCOPG2_IMPL=psycopg2cffi
 
 install: "pip install --use-mirrors tornado ${MOMOKO_PSYCOPG2_IMPL}"
@@ -22,20 +21,14 @@ script: python setup.py test
 matrix:
   exclude:
     - python: 3.2
-      env: MOMOKO_PSYCOPG2_IMPL=psycopg2ct
-    - python: 3.2
       env: MOMOKO_PSYCOPG2_IMPL=psycopg2cffi
     - python: 3.3
-      env: MOMOKO_PSYCOPG2_IMPL=psycopg2ct
-    - python: 3.3
       env: MOMOKO_PSYCOPG2_IMPL=psycopg2cffi
-    - python: 3.4
-      env: MOMOKO_PSYCOPG2_IMPL=psycopg2ct
     - python: 3.4
       env: MOMOKO_PSYCOPG2_IMPL=psycopg2cffi
     - python: pypy
       env: MOMOKO_PSYCOPG2_IMPL=psycopg2
 
       # Doesn't work on Travis CI
-    - python: pypy
-      env: MOMOKO_PSYCOPG2_IMPL=psycopg2cffi
+    #- python: pypy
+    #  env: MOMOKO_PSYCOPG2_IMPL=psycopg2cffi

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,8 +3,8 @@
 Installation
 ============
 
-Momoko supports Python 2 and 3 and PyPy with psycopg2ct_ or psycopg2cffi_.
-And the only dependencies are Tornado_ and Psycopg2_ (or psycopg2ct_/psycopg2cffi_).
+Momoko supports Python 2 and 3 and PyPy with psycopg2cffi_.
+And the only dependencies are Tornado_ and Psycopg2_ (or psycopg2cffi_).
 Installation is easy using *easy_install* or pip_::
 
     pip install momoko
@@ -15,11 +15,11 @@ The lastest source code can always be cloned from the `Github repository`_ with:
     cd momoko
     python setup.py install
 
-Psycopg2 is used by default when installing Momoko, but psycopg2ct or psycopg2cffi
+Psycopg2 is used by default when installing Momoko, but psycopg2cffi
 can also be used by setting the ``MOMOKO_PSYCOPG2_IMPL`` environment variable to
-``psycopg2ct`` or ``psycopg2cffi`` before running ``setup.py``. For example::
+``psycopg2cffi`` before running ``setup.py``. For example::
 
-    # 'psycopg2', 'psycopg2ct' or 'psycopg2cffi'
+    # 'psycopg2' or 'psycopg2cffi'
     export MOMOKO_PSYCOPG2_IMPL='psycopg2cffi'
 
 The unit tests als use this variable. It needs to be set if something else is used
@@ -42,7 +42,6 @@ And running the tests is easy::
    python setup.py test
 
 
-.. _psycopg2ct: http://pypi.python.org/pypi/psycopg2ct
 .. _psycopg2cffi: http://pypi.python.org/pypi/psycopg2cffi
 .. _Tornado: http://www.tornadoweb.org/
 .. _Psycopg2: http://initd.org/psycopg/


### PR DESCRIPTION
psycopg2ct github page says the project is deprecated. For instance it does not support `register_json` introduced in psycopg2-2.5.4.

Removing it from Travis CI tests and docs. Still left it in tests for people that may still use it.