### PR TITLE
pypy+psycopg2cffi works fine on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,3 @@ matrix:
       env: MOMOKO_PSYCOPG2_IMPL=psycopg2cffi
     - python: pypy
       env: MOMOKO_PSYCOPG2_IMPL=psycopg2
-
-      # Doesn't work on Travis CI
-    #- python: pypy
-    #  env: MOMOKO_PSYCOPG2_IMPL=psycopg2cffi


### PR DESCRIPTION
pypy+psycopg2cffi works fine on Travis CI - cleaning up .travis.yml