### PR TITLE
Add aliases to register_(hstore|json) methods for use with NamedTuples

### DIFF
--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -887,7 +887,7 @@ class Connection(object):
         registrator = partial(_psy_register_hstore, None, globally, unicode)
         callback = partial(self._register, future, registrator)
         self.ioloop.add_future(self.execute(
-            "SELECT 'hstore'::regtype::oid, 'hstore[]'::regtype::oid",
+            "SELECT 'hstore'::regtype::oid AS hstore_oid, 'hstore[]'::regtype::oid AS hstore_arr_oid",
         ), callback)
 
         return future
@@ -915,7 +915,7 @@ class Connection(object):
         registrator = partial(_psy_register_json, None, globally, loads)
         callback = partial(self._register, future, registrator)
         self.ioloop.add_future(self.execute(
-            "SELECT 'json'::regtype::oid, 'json[]'::regtype::oid"
+            "SELECT 'json'::regtype::oid AS json_oid, 'json[]'::regtype::oid AS json_arr_oid"
         ), callback)
 
         return future

--- a/tests.py
+++ b/tests.py
@@ -554,6 +554,20 @@ class MomokoPoolFactoriesTest(PoolBaseTest):
         cursor = yield db.execute("SELECT 1 AS a")
         self.assertEqual(cursor.fetchone(), {"a": 1})
 
+    @gen_test
+    def test_cursor_factory_with_extensions(self):
+        """Testing that NamedTupleCursor factory is working with hstore and json"""
+        db = yield self.build_pool(cur_factory=NamedTupleCursor)
+
+        yield db.register_hstore()
+        yield db.register_json()
+
+        cursor = yield self.db.execute("SELECT 'a=>b, c=>d'::hstore;")
+        self.assertEqual(cursor.fetchall(), [({"a": "b", "c": "d"},)])
+
+        cursor = yield self.db.execute("SELECT %s;", ({'e': 'f', 'g': 'h'},))
+        self.assertEqual(cursor.fetchall(), [({"e": "f", "g": "h"},)])
+
 
 class MomokoPoolParallelTest(PoolBaseTest):
     pool_size = 1


### PR DESCRIPTION
It is impossible to call register_hstore or register_json with NamedTupleCursor cursor factory because of conflicts in keys -- 'oid' and 'oid'. I added aliases to avoid this issue.