### PR TITLE
Fixed error handling when getting a connection.

### DIFF
--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -556,7 +556,7 @@ class Pool(object):
                 try:
                     ping_fut.result()
                 except psycopg2.Error as error:
-                    ping_future.set_exc_info(error)
+                    ping_future.set_exception(error)
                     self.putconn(conn)
                 else:
                     ping_future.set_result(conn)


### PR DESCRIPTION
Right now we are encountering a bug when someone resets the postgres-db service. The connections become stale. When psycopg2 Error is thrown set_exc_info with error throws another exception which causes the connection to not be put back in the connection pool (line 560 is not executed because line 559 blows up). Its in the the tornado concurrent exception traceback logger. 

It is trying to pass in the error into             
self.formatted_tb = traceback.format_exception(*exc_info) and exc_info is only 1 parameter and it excepts 3
This is in concurrent.py line 113

Changing it to set exception seems to make it work.