### PR TITLE
fix for any uncatchable internal exceptions

### DIFF
--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -752,10 +752,7 @@ class Connection(object):
         """
         kwargs = {"cursor_factory": cursor_factory} if cursor_factory else {}
         cursor = self.connection.cursor(**kwargs)
-        try:
-            cursor.execute(operation, parameters)
-        except:
-            raise psycopg2.DataError("bad python string")
+        cursor.execute(operation, parameters)
 
         future = Future()
         callback = partial(self._io_callback, future, cursor)

--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -752,7 +752,10 @@ class Connection(object):
         """
         kwargs = {"cursor_factory": cursor_factory} if cursor_factory else {}
         cursor = self.connection.cursor(**kwargs)
-        cursor.execute(operation, parameters)
+        try:
+            cursor.execute(operation, parameters)
+        except:
+            raise psycopg2.DataError("bad python string")
 
         future = Future()
         callback = partial(self._io_callback, future, cursor)

--- a/tests.py
+++ b/tests.py
@@ -580,6 +580,26 @@ class MomokoPoolDataTest(PoolBaseDataTest, MomokoConnectionDataTest):
                 pass
         self.assertEqual(len(self.db.conns.busy), 0, msg="Some connections were not recycled")
 
+    # Bad formed python string
+    @gen_test
+    def test_execute(self):
+        """Testing execute"""
+        try:
+            sql = yield self.conn.execute("SELECT COUNT(*) FROM unittest_large_query WHERE name LIKE %s;", ('%2',))
+        except psycopg2.Error as error:
+            pass
+        try:
+            search = "WHERE name LIKE '%%s'"
+            sql = yield self.conn.execute("SELECT COUNT(*) FROM unittest_large_query %s;" % search)
+        except psycopg2.Error as error:
+            pass
+        try: 
+            search = "WHERE name LIKE '%%searchable' LIMIT %s" % 10
+            sql = yield self.conn.execute("SELECT COUNT(*) FROM unittest_large_query %s;" % search)
+        except psycopg2.Error as error:
+            pass
+        
+
 
 class MomokoPoolDataTestProxy(ProxyMixIn, MomokoPoolDataTest):
     pass


### PR DESCRIPTION
There is the problem, when momoko fails with exception, such as, for example, IndexError for parameters, which is not catchable by Tornado. In the result of this behavior - this connection stays busy and inoperable. So, this little patch would catch these exceptions and throw them to Tornado