### PR TITLE
made connection allways synchronous.

### DIFF
--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -667,7 +667,7 @@ class Connection(object):
         Initiate asynchronous connect.
         Returns future that resolves to this connection object.
         """
-        kwargs = {"async": True}
+        kwargs = {"async": False}
         if self.connection_factory:
             kwargs["connection_factory"] = self.connection_factory
         if self.cursor_factory:


### PR DESCRIPTION
I made the call to psycopg2 connect method syncrhonous. Now when the script attempts to connect to the db server and the db server is not available for some reason, momoko properly detects the dead connection. As soon as the server is available and the app is accessed, momoko properly connects to the database.