### PR TITLE
Fix tcproxy build error

### DIFF
--- a/tcproxy/src/policy.c
+++ b/tcproxy/src/policy.c
@@ -219,10 +219,6 @@ static const char _policy_parser_eof_actions[] = {
 };
 
 static const int policy_parser_start = 1;
-static const int policy_parser_first_final = 99;
-static const int policy_parser_error = 0;
-
-static const int policy_parser_en_main = 1;
 
 
 #line 95 "policy.rl"


### PR DESCRIPTION
Got error
```
(venv6) nkonin@Mac-mini-Nikita:~/projects/momoko$ make -C tcproxy
cd src && /Library/Developer/CommandLineTools/usr/bin/make all
    CC tcproxy.o
    CC ae.o
    CC util.o
    CC policy.o
policy.c:222:18: error: unused variable 'policy_parser_first_final'
      [-Werror,-Wunused-const-variable]
static const int policy_parser_first_final = 99;
                 ^
policy.c:223:18: error: unused variable 'policy_parser_error'
      [-Werror,-Wunused-const-variable]
static const int policy_parser_error = 0;
                 ^
policy.c:225:18: error: unused variable 'policy_parser_en_main'
      [-Werror,-Wunused-const-variable]
static const int policy_parser_en_main = 1;
                 ^
3 errors generated.
make[1]: *** [policy.o] Error 1
make: *** [all] Error 2
```

Remove unsed variables from error message
```
(venv6) nkonin@Mac-mini-Nikita:~/projects/momoko$ git diff
diff --git a/tcproxy/src/policy.c b/tcproxy/src/policy.c
index 0b590da..abcd6ff 100644
--- a/tcproxy/src/policy.c
+++ b/tcproxy/src/policy.c
@@ -219,10 +219,6 @@ static const char _policy_parser_eof_actions[] = {
 };

 static const int policy_parser_start = 1;
-static const int policy_parser_first_final = 99;
-static const int policy_parser_error = 0;
-
-static const int policy_parser_en_main = 1;


 #line 95 "policy.rl"
```

And now it's ok
```
(venv6) nkonin@Mac-mini-Nikita:~/projects/momoko$ make -C tcproxy
cd src && /Library/Developer/CommandLineTools/usr/bin/make all
    CC policy.o
    CC zmalloc.o
    CC anet.o
    LINK tcproxy

Make Complete. Read README for how to use.

Having problems with it? Send complains and bugs to dccmx@dccmx.com

(venv6) nkonin@Mac-mini-Nikita:~/projects/momoko$
```