### PR TITLE
Added Python 3.7 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
   - pypy
 
 addons:

--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -414,7 +414,7 @@ class Pool(object):
         See :py:meth:`momoko.Connection.mogrify` for documentation about the
         parameters.
         """
-        return self._operate(Connection.mogrify, args, kwargs, async=False)
+        return self._operate(Connection.mogrify, args, kwargs, async_flag=False)
 
     def register_hstore(self, *args, **kwargs):
         """
@@ -451,7 +451,7 @@ class Pool(object):
         self.conns.empty()
         self.closed = True
 
-    def _operate(self, method, args=(), kwargs=None, async=True, keep=False, connection=None):
+    def _operate(self, method, args=(), kwargs=None, async_flag=True, keep=False, connection=None):
         kwargs = kwargs or {}
         future = Future()
 
@@ -473,7 +473,7 @@ class Pool(object):
                 log.debug("Method failed synchronously")
                 return self._retry(retry, when_available, conn, keep, future)
 
-            if not async:
+            if not async_flag:
                 future.set_result(future_or_result)
                 if not keep:
                     self.putconn(conn)


### PR DESCRIPTION
Renamed 'async' variable to 'async_flag' to avoid conflicts with Python 3.7's 'async' keyword.